### PR TITLE
Disable mixin updates & minimum release age check for incompatible types/sources

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,28 @@
       "matchManagers": ["helmv3", "helm-values", "helmfile"],
       "groupName": "Helm updates",
       "groupSlug": "helm-updates"
+    },
+    {
+      "description": "Exclude mixin vendoring from lockfile maintenance",
+      "matchFileNames": ["**/jsonnetfile.json", "**/jsonnetfile.lock.json"],
+      "lockFileMaintenance": {
+        "enabled": false
+      }
+    },
+    {
+      "description": "Disable minimum release age check for update types that don't support timestamps",
+      "matchUpdateTypes": ["pin", "pinDigest", "digest"],
+      "minimumReleaseAge": null
+    },
+    {
+      "description": "Disable minimum release age for specific images in container registries that don't provide release timestamps (ghcr.io, quay.io).",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "ghcr.io/observiq/varnish-exporter",
+        "ghcr.io/oracle/oraclelinux9-instantclient",
+        "quay.io/prometheus/statsd-exporter"
+      ],
+      "minimumReleaseAge": null
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -42,9 +42,7 @@
       "description": "Disable minimum release age for specific images in container registries that don't provide release timestamps (ghcr.io, quay.io).",
       "matchDatasources": ["docker"],
       "matchPackageNames": [
-        "ghcr.io/observiq/varnish-exporter",
-        "ghcr.io/oracle/oraclelinux9-instantclient",
-        "quay.io/prometheus/statsd-exporter"
+        "quay.io/prometheus/busybox"
       ],
       "minimumReleaseAge": null
     }


### PR DESCRIPTION
What the title says. Some of our renovate updates get blocked hard by the minimum release age check and can't be bypassed on the PR without this.

Additionally adds an exclude to disable lockfile maintenance for the mixin (both directly and through vendoring) as we want to control this during manual updates only.

Source: https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-datasources-support-release-timestamps